### PR TITLE
Allow migrations to run with empty database

### DIFF
--- a/db/migrate/20151024040622_fix_navcam_null_camera_ids_for_curiosity_photos.rb
+++ b/db/migrate/20151024040622_fix_navcam_null_camera_ids_for_curiosity_photos.rb
@@ -1,10 +1,18 @@
 class FixNavcamNullCameraIdsForCuriosityPhotos < ActiveRecord::Migration
+  class Rover < ActiveRecord::Base
+    has_many :cameras
+    has_many :photos
+  end
+
   def up
     curiosity = Rover.find_by(name: "Curiosity")
-    navcam = curiosity.cameras.find_by(name: "NAVCAM")
 
-    photos = curiosity.photos.where(camera: nil)
-    photos.update_all(camera_id: navcam.id)
+    if curiosity
+      navcam = curiosity.cameras.find_by(name: "NAVCAM")
+
+      photos = curiosity.photos.where(camera: nil)
+      photos.update_all(camera_id: navcam.id)
+    end
   end
 
   def down


### PR DESCRIPTION
This migration could not be run with a fresh database because it was
relying on the “Curiosity” rover to exist in the database.

It was also relying on the existence of a `Rover` class, which has now
been defined at the top of the migration to ensure that even if this
class is renamed/moved etc., this migration will still work.