### PR TITLE
Permit :rover_id

### DIFF
--- a/app/controllers/api/v1/latest_photos_controller.rb
+++ b/app/controllers/api/v1/latest_photos_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::LatestPhotosController < ApplicationController
   private
 
   def photo_params
-    params.permit(:camera, :earth_date).merge(sol: @rover.photos.maximum(:sol))
+    params.permit(:camera, :earth_date, :rover_id).merge(sol: @rover.photos.maximum(:sol))
   end
 
   def search_photos

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::PhotosController < ApplicationController
   private
 
   def photo_params
-    params.permit :sol, :camera, :earth_date
+    params.permit :sol, :camera, :earth_date, :rover_id
   end
 
   def photos(rover)


### PR DESCRIPTION
Explicitly permitted `:rover_id` parameter in photos_controller.rb and latest_photos_controller.rb. This was logging a non-breaking warning in my console: `Unpermitted parameter: :rover_id`