### PR TITLE
Fix PerseveranceScraper RSpec test coverage

### DIFF
--- a/app/models/perseverance_scraper.rb
+++ b/app/models/perseverance_scraper.rb
@@ -53,31 +53,8 @@ class PerseveranceScraper
     end
   end
 
-  def camera_abbreviations
-    {
-      erucam:  "EDL_RUCAM",
-      erdcam:  "EDL_RDCAM",
-      edocam:  "EDL_DDCAM",
-      epu1cam: "EDL_PUCAM1",
-      epu2cam: "EDL_PUCAM2",
-      navlcam: "NAVCAM_LEFT",
-      navrcam: "NAVCAM_RIGHT",
-      mczlcam: "MCZ_LEFT",
-      mczrcam: "MCZ_RIGHT",
-      fhlacam: "FRONT_HAZCAM_LEFT_A",
-      fhracam: "FRONT_HAZCAM_RIGHT_A",
-      fhlbcam: "FRONT_HAZCAM_LEFT_B",
-      fhrbcam: "FRONT_HAZCAM_RIGHT_B",
-      rhlcam:  "REAR_HAZCAM_LEFT",
-      rhrcam:  "REAR_HAZCAM_RIGHT",
-      skycam:  "SKYCAM",
-      watson:  "SHERLOC_WATSON"
-    }
-  end
-
   def camera_from_json(image)
     camera_name = image['camera']['instrument']
     rover.cameras.find_by(name: camera_name) || camera_name
   end
 end
-

--- a/spec/models/perseverance_scraper_spec.rb
+++ b/spec/models/perseverance_scraper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PerseveranceScraper, type: :model do
     it "should create photo objects" do
       allow(scraper).to receive(:collect_links).and_return ["https://mars.nasa.gov/rss/api/?feed=raw_images&category=mars2020&feedtype=json&sol=1"]
 
-      expect{ scraper.scrape }.to change { Photo.count }.by(205)
+      expect{ scraper.scrape }.to change { Photo.count }.by(34)
     end
   end
 end

--- a/spec/models/perseverance_scraper_spec.rb
+++ b/spec/models/perseverance_scraper_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe PerseveranceScraper, type: :model do
   let!(:perseverance) { create(:rover, name: "Perseverance", landing_date: Date.new(2021, 2, 18), launch_date: Date.new(2020, 7, 30), status: "active") }
   let(:scraper) { PerseveranceScraper.new }
+
   describe "#rover" do
     it "should be Perseverance" do
       expect(scraper.rover).to eq perseverance
@@ -39,6 +40,22 @@ RSpec.describe PerseveranceScraper, type: :model do
       allow(scraper).to receive(:collect_links).and_return ["https://mars.nasa.gov/rss/api/?feed=raw_images&category=mars2020&feedtype=json&sol=1"]
 
       expect{ scraper.scrape }.to change { Photo.count }.by(34)
+    end
+
+    context "finds an invalid camera name" do
+      before(:each) do
+        allow($stdout).to receive(:write) # stub stdout
+        allow(scraper).to receive(:collect_links).and_return ["https://mars.nasa.gov/rss/api/?feed=raw_images&category=mars2020&feedtype=json&sol=1"]
+        allow(scraper).to receive(:camera_from_json).and_return('NOT_A_CAMERA')
+      end
+
+      it "should not create any photos" do
+        expect { scraper.scrape }.to change { Photo.count }.by(0)
+      end
+
+      it "should print a warning" do
+        expect { scraper.scrape }.to output(/WARNING: Camera not found. Name: NOT_A_CAMERA/).to_stdout
+      end
     end
   end
 end

--- a/spec/models/perseverance_scraper_spec.rb
+++ b/spec/models/perseverance_scraper_spec.rb
@@ -17,23 +17,23 @@ RSpec.describe PerseveranceScraper, type: :model do
   end
 
   describe ".scrape" do
-    let!(:erucam) {create :camera, rover: perseverance, name:  "EDL_RUCAM" }
-    let!(:erdcam) {create :camera, rover: perseverance, name:  "EDL_RDCAM" }
-    let!(:edocam) {create :camera, rover: perseverance, name:  "EDL_DDCAM" }
-    let!(:epu1cam) {create :camera, rover: perseverance, name: "EDL_PUCAM1" }
-    let!(:epu2cam) {create :camera, rover: perseverance, name: "EDL_PUCAM2" }
-    let!(:navlcam) {create :camera, rover: perseverance, name: "NAVCAM_LEFT" }
-    let!(:navrcam) {create :camera, rover: perseverance, name: "NAVCAM_RIGHT" }
-    let!(:mczlcam) {create :camera, rover: perseverance, name: "MCZ_LEFT" }
-    let!(:mczrcam) {create :camera, rover: perseverance, name: "MCZ_RIGHT" }
-    let!(:fhlacam) {create :camera, rover: perseverance, name: "FRONT_HAZCAM_LEFT_A" }
-    let!(:fhracam) {create :camera, rover: perseverance, name: "FRONT_HAZCAM_RIGHT_A" }
-    let!(:fhlbcam) {create :camera, rover: perseverance, name: "FRONT_HAZCAM_LEFT_B" }
-    let!(:fhrbcam) {create :camera, rover: perseverance, name: "FRONT_HAZCAM_RIGHT_B" }
-    let!(:rhlcam) {create :camera, rover: perseverance, name:  "REAR_HAZCAM_LEFT" }
-    let!(:rhrcam) {create :camera, rover: perseverance, name:  "REAR_HAZCAM_RIGHT" }
-    let!(:skycam) {create :camera, rover: perseverance, name:  "SKYCAM" }
-    let!(:waston) {create :camera, rover: perseverance, name:  "SHERLOC_WATSON" }
+    let!(:erucam) { create :camera, rover: perseverance, name: "EDL_RUCAM" }
+    let!(:erdcam) { create :camera, rover: perseverance, name: "EDL_RDCAM" }
+    let!(:edocam) { create :camera, rover: perseverance, name: "EDL_DDCAM" }
+    let!(:epu1cam) { create :camera, rover: perseverance, name: "EDL_PUCAM1" }
+    let!(:epu2cam) { create :camera, rover: perseverance, name: "EDL_PUCAM2" }
+    let!(:navlcam) { create :camera, rover: perseverance, name: "NAVCAM_LEFT" }
+    let!(:navrcam) { create :camera, rover: perseverance, name: "NAVCAM_RIGHT" }
+    let!(:mczlcam) { create :camera, rover: perseverance, name: "MCZ_LEFT" }
+    let!(:mczrcam) { create :camera, rover: perseverance, name: "MCZ_RIGHT" }
+    let!(:fhlacam) { create :camera, rover: perseverance, name: "FRONT_HAZCAM_LEFT_A" }
+    let!(:fhracam) { create :camera, rover: perseverance, name: "FRONT_HAZCAM_RIGHT_A" }
+    let!(:fhlbcam) { create :camera, rover: perseverance, name: "FRONT_HAZCAM_LEFT_B" }
+    let!(:fhrbcam) { create :camera, rover: perseverance, name: "FRONT_HAZCAM_RIGHT_B" }
+    let!(:rhlcam) { create :camera, rover: perseverance, name: "REAR_HAZCAM_LEFT" }
+    let!(:rhrcam) { create :camera, rover: perseverance, name: "REAR_HAZCAM_RIGHT" }
+    let!(:skycam) { create :camera, rover: perseverance, name: "SKYCAM" }
+    let!(:waston) { create :camera, rover: perseverance, name: "SHERLOC_WATSON" }
     let!(:supercam) { create :camera, rover: perseverance, name: "SUPERCAM_RMI" }
 
     before(:each) do

--- a/spec/models/perseverance_scraper_spec.rb
+++ b/spec/models/perseverance_scraper_spec.rb
@@ -36,16 +36,17 @@ RSpec.describe PerseveranceScraper, type: :model do
     let!(:waston) {create :camera, rover: perseverance, name:  "SHERLOC_WATSON" }
     let!(:supercam) { create :camera, rover: perseverance, name: "SUPERCAM_RMI" }
 
-    it "should create photo objects" do
+    before(:each) do
       allow(scraper).to receive(:collect_links).and_return ["https://mars.nasa.gov/rss/api/?feed=raw_images&category=mars2020&feedtype=json&sol=1"]
+    end
 
+    it "should create photo objects" do
       expect{ scraper.scrape }.to change { Photo.count }.by(34)
     end
 
     context "finds an invalid camera name" do
       before(:each) do
         allow($stdout).to receive(:write) # stub stdout
-        allow(scraper).to receive(:collect_links).and_return ["https://mars.nasa.gov/rss/api/?feed=raw_images&category=mars2020&feedtype=json&sol=1"]
         allow(scraper).to receive(:camera_from_json).and_return('NOT_A_CAMERA')
       end
 


### PR DESCRIPTION
Fix the failing RSpec test `PerseveranceScraper.scrape should create photo objects` (#146) by altering the expected change in photo count from `205` to `34`.

The json data only contains 34 photos:
https://mars.nasa.gov/rss/api/?feed=raw_images&category=mars2020&feedtype=json&sol=1